### PR TITLE
[WIP] port this to node-gyp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,17 @@
-os: osx
 language: node_js
+os:
+  - osx
 node_js:
-  - '6'
-  - '4'
+  - "7.0"
+  - "6.0"
+  - "4.0"
+
+notifications:
+  email: false
+
+git:
+  depth: 10
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
This PR addresses a couple of limitations with the current library:

 - it's precompiled, so cannot be used in situations where the runtime is different (such as Electron)
 - we can be more efficient about how the library is invoked, by using `node-gyp` to create the native module rather than spawning a process
 - we can use `nan` (node's native abstractions) to structure this code and handle marshalling strings and exit codes, rather than using `stdout`

 - [ ] get native module building using `nan` and `node-gyp`
 - [ ] update tests to use this new module
 - [ ] remove existing `main` binary